### PR TITLE
Fix importing of pip.req

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@
 
 import re
 
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
 try:


### PR DESCRIPTION
pip 10 broke compatibility with this module. Fixed!

for: https://github.com/intercom/intercom/issues/101311